### PR TITLE
Fix example in stat command help text

### DIFF
--- a/sizebot/cogs/stats.py
+++ b/sizebot/cogs/stats.py
@@ -92,8 +92,8 @@ class StatsCog(commands.Cog):
 
         Examples:
         `&stat height` (not specifying a user returns a stat about yourself.)
-        `&stats @User weight`
-        `&stats 10ft foot`
+        `&stat weight @User`
+        `&stat foot 10ft`
         """
 
         statmap = {


### PR DESCRIPTION
The example text in the stat command were invalid